### PR TITLE
Fix dictionary init in database sync

### DIFF
--- a/sources/utils/autoloads/user_database_synchronizer.gd
+++ b/sources/utils/autoloads/user_database_synchronizer.gd
@@ -141,7 +141,7 @@ func synchronize() -> void:
 						need_update_students[student_data.code] = UpdateNeeded.FromLocal
 					else:
 						Logger.warn("UserDataBaseSynchronizer: Student %d not found in server, but user doesn't need to be updated...this is theoretically not possible" % student_data.code)
-	var message_to_server: Dictionary
+	var message_to_server: Dictionary = {}
 	if need_update_user == UpdateNeeded.Nothing:
 		pass
 	elif need_update_user == UpdateNeeded.FromLocal:


### PR DESCRIPTION
## Summary
- initialize `message_to_server` dictionary before use
- use tab indentation for this line

## Testing
- `python3 .github/scripts/check_file_naming.py`


------
https://chatgpt.com/codex/tasks/task_e_684346590b08832b880308c5e126e40a