### PR TITLE
Add GDScript naming convention workflow

### DIFF
--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -9,6 +9,13 @@ SNAKE_CASE = re.compile(r"^_?[a-z][a-z0-9_]*$")
 UPPER_SNAKE_CASE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 issues = []
+MESSAGES = {
+    'class': 'is a class name and should be in PascalCase',
+    'function': 'is a function name and should be in snake_case',
+    'variable': 'is a variable name and should be in snake_case',
+    'constant': 'is a constant name and should be in UPPER_SNAKE_CASE',
+    'signal': 'is a signal name and should be in snake_case',
+}
 
 for root, dirs, files in os.walk('.', topdown=True):
     rel_root = os.path.relpath(root, '.')
@@ -57,7 +64,11 @@ for root, dirs, files in os.walk('.', topdown=True):
 if issues:
     print('GDScript naming issues found:')
     for path, idx, kind, name in issues:
-        print(f"{path}:{idx}: {kind} '{name}' does not follow convention")
+        if kind == 'error':
+            message = name
+        else:
+            message = f"'{name}' {MESSAGES[kind]}"
+        print(f"{path}:{idx}: {message}")
     sys.exit(1)
 else:
     print('All GDScript files follow the naming conventions.')

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -77,6 +77,7 @@ for root, dirs, files in os.walk('.', topdown=True):
                         issues.append((path, idx, 'variable', name))
 
 if issues:
+    print(f"Total issues: {len(issues)}")
     print('GDScript naming issues found:')
     for path, idx, kind, name in issues:
         if kind == 'error':
@@ -84,7 +85,6 @@ if issues:
         else:
             message = f"'{name}' {MESSAGES[kind]}"
         print(f"{path}:{idx}: {message}")
-    print(f"Total issues: {len(issues)}")
     sys.exit(1)
 else:
     print('All GDScript files follow the naming conventions.')

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -69,6 +69,7 @@ if issues:
         else:
             message = f"'{name}' {MESSAGES[kind]}"
         print(f"{path}:{idx}: {message}")
+    print(f"Total issues: {len(issues)}")
     sys.exit(1)
 else:
     print('All GDScript files follow the naming conventions.')

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -60,6 +60,11 @@ for root, dirs, files in os.walk('.', topdown=True):
                     name = m.group(1)
                     if not SNAKE_CASE.match(name):
                         issues.append((path, idx, 'signal', name))
+                m = re.match(r"for\s+([A-Za-z0-9_]+)(?:\s*:\s*[^\s]+)?\s+in\b", stripped)
+                if m:
+                    name = m.group(1)
+                    if not SNAKE_CASE.match(name):
+                        issues.append((path, idx, 'variable', name))
 
 if issues:
     print('GDScript naming issues found:')

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -6,6 +6,9 @@ EXCLUDED_DIRS = {"addons", ".git", ".github"}
 
 PASCAL_CASE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
 SNAKE_CASE = re.compile(r"^_?[a-z][a-z0-9_]*$")
+
+# Allow constants in regular snake_case as well
+LOWER_SNAKE_CASE = SNAKE_CASE
 UPPER_SNAKE_CASE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 issues = []
@@ -48,8 +51,9 @@ for root, dirs, files in os.walk('.', topdown=True):
                     params = m.group(2)
                     if params:
                         params = params.strip('()')
-                        for param in params.split(','):
-                            param_name = param.strip()
+                # Constants can optionally start with an underscore. They may be in
+                # upper snake case or regular snake case.
+                    if not UPPER_SNAKE_CASE.match(name) and not LOWER_SNAKE_CASE.match(name):
                             if not param_name:
                                 continue
                             param_name = param_name.split(':')[0].split('=')[0].strip()

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -1,0 +1,63 @@
+import os
+import re
+import sys
+
+EXCLUDED_DIRS = {"addons", ".git", ".github"}
+
+PASCAL_CASE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+SNAKE_CASE = re.compile(r"^_?[a-z][a-z0-9_]*$")
+UPPER_SNAKE_CASE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+issues = []
+
+for root, dirs, files in os.walk('.', topdown=True):
+    rel_root = os.path.relpath(root, '.')
+    if any(rel_root == ex or rel_root.startswith(f"{ex}{os.sep}") for ex in EXCLUDED_DIRS):
+        dirs[:] = []
+        continue
+    for fname in files:
+        if fname.endswith('.gd'):
+            path = os.path.join(root, fname)
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    lines = f.readlines()
+            except Exception as e:
+                issues.append((path, 0, 'error', f'Could not read file: {e}'))
+                continue
+            for idx, line in enumerate(lines, 1):
+                stripped = line.strip()
+                if stripped.startswith('#') or not stripped:
+                    continue
+                m = re.match(r"class_name\s+([A-Za-z0-9_]+)", stripped)
+                if m:
+                    name = m.group(1)
+                    if not PASCAL_CASE.match(name):
+                        issues.append((path, idx, 'class', name))
+                m = re.match(r"func\s+([A-Za-z0-9_]+)", stripped)
+                if m:
+                    name = m.group(1).split('(')[0]
+                    if not SNAKE_CASE.match(name):
+                        issues.append((path, idx, 'function', name))
+                m = re.match(r"(?:@export\s+)?var\s+([A-Za-z0-9_]+)", stripped)
+                if m:
+                    name = m.group(1)
+                    if not SNAKE_CASE.match(name):
+                        issues.append((path, idx, 'variable', name))
+                m = re.match(r"const\s+([A-Za-z0-9_]+)", stripped)
+                if m:
+                    name = m.group(1)
+                    if not UPPER_SNAKE_CASE.match(name):
+                        issues.append((path, idx, 'constant', name))
+                m = re.match(r"signal\s+([A-Za-z0-9_]+)", stripped)
+                if m:
+                    name = m.group(1)
+                    if not SNAKE_CASE.match(name):
+                        issues.append((path, idx, 'signal', name))
+
+if issues:
+    print('GDScript naming issues found:')
+    for path, idx, kind, name in issues:
+        print(f"{path}:{idx}: {kind} '{name}' does not follow convention")
+    sys.exit(1)
+else:
+    print('All GDScript files follow the naming conventions.')

--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -40,11 +40,21 @@ for root, dirs, files in os.walk('.', topdown=True):
                     name = m.group(1)
                     if not PASCAL_CASE.match(name):
                         issues.append((path, idx, 'class', name))
-                m = re.match(r"func\s+([A-Za-z0-9_]+)", stripped)
+                m = re.match(r"func\s+([A-Za-z0-9_]+)\s*(\([^)]*\))?", stripped)
                 if m:
-                    name = m.group(1).split('(')[0]
+                    name = m.group(1)
                     if not SNAKE_CASE.match(name):
                         issues.append((path, idx, 'function', name))
+                    params = m.group(2)
+                    if params:
+                        params = params.strip('()')
+                        for param in params.split(','):
+                            param_name = param.strip()
+                            if not param_name:
+                                continue
+                            param_name = param_name.split(':')[0].split('=')[0].strip()
+                            if param_name and not SNAKE_CASE.match(param_name):
+                                issues.append((path, idx, 'variable', param_name))
                 m = re.match(r"(?:@export\s+)?var\s+([A-Za-z0-9_]+)", stripped)
                 if m:
                     name = m.group(1)

--- a/.github/workflows/gdscript-naming.yml
+++ b/.github/workflows/gdscript-naming.yml
@@ -1,0 +1,34 @@
+name: GDScript Naming Convention
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  gdscript_naming:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run GDScript naming convention check
+        id: naming
+        run: |
+          python3 .github/scripts/check_gd_nomenclature.py > gd_naming_output.txt
+        continue-on-error: true
+      - name: Comment on PR with naming convention output
+        if: steps.naming.outcome != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('gd_naming_output.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+      - name: Fail if naming convention check failed
+        if: steps.naming.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
## Summary
- enforce Godot 4.4 GDScript style with `check_gd_nomenclature.py`
- run the script in a new `gdscript-naming.yml` workflow that comments on PRs

## Testing
- `python3 .github/scripts/check_gd_nomenclature.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68434a9eb804832b9a0c6bdd21b7a7ab