### PR TITLE
Fix constant naming false positives

### DIFF
--- a/.github/scripts/check_gd_nomenclature.py
+++ b/.github/scripts/check_gd_nomenclature.py
@@ -6,7 +6,7 @@ EXCLUDED_DIRS = {"addons", ".git", ".github"}
 
 PASCAL_CASE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
 SNAKE_CASE = re.compile(r"^_?[a-z][a-z0-9_]*$")
-UPPER_SNAKE_CASE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+UPPER_SNAKE_CASE = re.compile(r"^_?[A-Z][A-Z0-9_]*$")
 
 issues = []
 MESSAGES = {


### PR DESCRIPTION
## Summary
- allow underscore-prefixed constants in gdscript naming check

## Testing
- `python3 .github/scripts/check_file_naming.py | head`
- `python3 .github/scripts/check_gd_nomenclature.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6847349ef4b8832b8092b4ae4cabc19b