### PR TITLE
Fix binder cast for TextEdit

### DIFF
--- a/sources/utils/binder/control_binder.gd
+++ b/sources/utils/binder/control_binder.gd
@@ -40,8 +40,10 @@ func set_value(value: Variant) -> void:
 			(control as Range).value = value
 		elif value is int:
 			(control as Range).value = float(value as int)
-	elif control is LineEdit or control is TextEdit:
+	elif control is LineEdit:
 		(control as LineEdit).text = str(value)
+	elif control is TextEdit:
+		(control as TextEdit).text = str(value)
 	elif control is ItemList:
 		if value is int:
 			(control as ItemList).select(value as int, true)


### PR DESCRIPTION
## Summary
- fix binder logic so TextEdit controls are properly bound

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d573292dc832bbb58ff21f12dc7a1