### PR TITLE
Remove temp folders and local-only folders from the file-naming check

### DIFF
--- a/.github/scripts/check_file_naming.py
+++ b/.github/scripts/check_file_naming.py
@@ -13,7 +13,7 @@ TARGET_EXTS = {
 }
 
 # Directories to ignore entirely (e.g., external or tooling folders)
-EXCLUDED_DIRS = {"addons", "script_templates", ".git", ".github"}
+EXCLUDED_DIRS = {"addons", "script_templates", ".git", ".github", ".godot", "android"}
 
 invalid_files = []
 invalid_dirs = []


### PR DESCRIPTION
This PR goes with https://github.com/Excello-Recherche-Education/Kalulu/pull/58
To allow local tests to run without errors because of files ignored by versioning