### PR TITLE
Level progression

### DIFF
--- a/sources/menus/main/login.gd
+++ b/sources/menus/main/login.gd
@@ -43,6 +43,7 @@ func _on_validate_button_pressed() -> void:
 		# Login
 		if UserDataManager.login(res.body as Dictionary):
 			logged_in.emit()
+			UserDataManager.user_database_synchronizer.synchronize()
 		else:
 			login_message.visible = true
 	else:

--- a/sources/menus/main/login.gd
+++ b/sources/menus/main/login.gd
@@ -42,8 +42,8 @@ func _on_validate_button_pressed() -> void:
 	if res.code == 200:
 		# Login
 		if UserDataManager.login(res.body as Dictionary):
+			await UserDataManager.user_database_synchronizer.synchronize()
 			logged_in.emit()
-			UserDataManager.user_database_synchronizer.synchronize()
 		else:
 			login_message.visible = true
 	else:

--- a/sources/utils/autoloads/server_manager.gd
+++ b/sources/utils/autoloads/server_manager.gd
@@ -60,11 +60,6 @@ func login(mail: String, password: String) -> Dictionary:
 	return _response()
 
 
-func get_configuration() -> Dictionary:
-	await _get_request("configuration", {})
-	return _response()
-
-
 func delete_account() -> Dictionary:
 	loading_rect.show()
 	await _delete_request("delete_account")


### PR DESCRIPTION
Force a synchronization after first login, to prevent creation of new data when old data is available
This was the reason why a user had "empty" level progression when using a new device.