### PR TITLE
Security if language pack has less than 3 exercices in lesson

### DIFF
--- a/sources/gardens/gardens.gd
+++ b/sources/gardens/gardens.gd
@@ -695,13 +695,14 @@ func _get_minigame_layouts() -> Array[MinigameLayout]:
 func _open_minigames_layout(button: LessonButton, lesson_number: int) -> void:
 	if in_minigame_selection or not UserDataManager.student_progression:
 		return
-	feedback_audio_stream_player2.pitch_scale = 1.1
-	feedback_audio_stream_player2.play()
-	in_minigame_selection = true
 	# Gets the correct exercises for the lesson
 	var exercises: Array[int] = Database.get_exercise_for_lesson(lesson_number)
 	if not exercises or exercises.size() < 3:
+		Log.error("Gardens: Cannot open minigame layout for lesson %d: expected 3 exercises, got %d" % [lesson_number, exercises.size() if exercises else 0])
 		return
+	feedback_audio_stream_player2.pitch_scale = 1.1
+	feedback_audio_stream_player2.play()
+	in_minigame_selection = true
 	# Sets the variables for the current garden and lesson
 	current_lesson_number = lesson_number
 	var garden_index_for_lesson: int = _get_garden_index_for_lesson(lesson_number)


### PR DESCRIPTION
The bug:
In _open_minigames_layout, the order was:

Set in_minigame_selection = true
Fetch exercises from the database
Early-return without resetting the flag if exercises are missing/incomplete
Once that early return fired, in_minigame_selection stayed true forever — the guard at the top (if in_minigame_selection: return) blocked every subsequent lesson-button click, plus all the scroll/back-button paths that check the same flag. The only way out was killing the app. No log was emitted either, so the failure was silent.

Trigger condition: A lesson with fewer than 3 entries in the ExerciseTypes/LessonsExercises tables — realistic for a freshly-imported or partially-edited language pack from the Prof Tool, or a lesson where the linguist forgot to assign all three exercises.

The fix:

Move the exercises validation before the state mutation, so a missing-data lesson doesn't consume the click.
Add an Log.error so this failure mode is observable instead of silent.